### PR TITLE
[BugFix] Fix error in Godot 4.2+

### DIFF
--- a/addons/multirun/Multirun.gd
+++ b/addons/multirun/Multirun.gd
@@ -12,8 +12,8 @@ func _str_args_to_commands(args:String):
 	return commands
 
 func _enter_tree():
-	var editor_node = get_tree().get_root().get_child(0)
-	var gui_base = editor_node.get_gui_base()
+	var editor_node = get_editor_interface()
+	var gui_base = editor_node.get_base_control()
 	var icon_transition = gui_base.get_theme_icon("TransitionSync", "EditorIcons") #ToolConnect
 	var icon_transition_auto = gui_base.get_theme_icon("TransitionSyncAuto", "EditorIcons")
 	var icon_load = gui_base.get_theme_icon("Load", "EditorIcons")

--- a/addons/multirun/plugin.cfg
+++ b/addons/multirun/plugin.cfg
@@ -3,5 +3,5 @@
 name="Multirun"
 description="Multirun allows to start multiple game instances at once."
 author="Dennis Fehr"
-version="1.1.1"
+version="1.1.2"
 script="Multirun.gd"


### PR DESCRIPTION
Now using `get_editor_interface()` instead. This will fix issue #5 